### PR TITLE
Workaround for bound methods

### DIFF
--- a/src/main/java/net/lahwran/bukkit/jython/PythonCommandHandler.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonCommandHandler.java
@@ -58,10 +58,10 @@ public class PythonCommandHandler implements CommandExecutor {
                 argcount = 4;
             } catch (PyException e) {
               //this could goof up someone ... they'll probably yell at us and eventually read this code ... fuck them
-                if (e.type == Py.TypeError && e.value.toString().endsWith("takes exactly 3 arguments (4 given)")) {
+                if (e.type == Py.TypeError && (e.value.toString().endsWith("takes exactly 3 arguments (4 given)") || e.value.toString().endsWith("takes exactly 4 arguments (5 given)"))) {
                     result = call(3, sender, command, label, args);
                     argcount = 3;
-                } else if (e.type == Py.TypeError && e.value.toString().endsWith("takes exactly 2 arguments (4 given)")) {
+                } else if (e.type == Py.TypeError && (e.value.toString().endsWith("takes exactly 2 arguments (4 given)") || e.value.toString().endsWith("takes exactly 3 arguments (5 given)"))) {
                     result = call(2, sender, command, label, args);
                     argcount = 2;
                 } else {

--- a/src/main/java/net/lahwran/bukkit/jython/PythonCommandHandler.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonCommandHandler.java
@@ -13,7 +13,7 @@ import org.python.core.*;
  */
 public class PythonCommandHandler implements CommandExecutor {
 
-    private final PyFunction func;
+    private final PyObject func;
     private final String name;
     private int argcount = -1;
 
@@ -21,7 +21,7 @@ public class PythonCommandHandler implements CommandExecutor {
      * @param func function to handle
      * @param name name of command to use when registering
      */
-    public PythonCommandHandler(PyFunction func, String name) {
+    public PythonCommandHandler(PyObject func, String name) {
         this.func = func;
         this.name = name;
     }

--- a/src/main/java/net/lahwran/bukkit/jython/PythonHooks.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonHooks.java
@@ -253,7 +253,6 @@ public class PythonHooks {
     }
 
     public void register(final PyObject instance) {
-    	System.out.println(instance.getClass().toString());
     	for (String deferred : deferredhandlers) {
     		try {
     			final PyObject func = instance.__getattr__(deferred);

--- a/src/main/java/net/lahwran/bukkit/jython/PythonPlugin.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonPlugin.java
@@ -52,7 +52,7 @@ private boolean isEnabled = false;
     private File configFile = null;
     private PluginLogger logger = null;
     private PluginDataFile dataFile = null; //data file used for retrieving resources
-
+    
     /**
      * Listener to handle all PythonHooks events for this plugin.
      */

--- a/src/main/java/net/lahwran/bukkit/jython/PythonPluginLoader.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonPluginLoader.java
@@ -221,8 +221,11 @@ public class PythonPluginLoader implements PluginLoader {
 
             PythonInterpreter interp = new PythonInterpreter();
 
+            interp.exec("import __builtin__");
             interp.set("hook", hook);
+            interp.exec("__builtin__.hook = hook");
             interp.set("info", description);
+            interp.exec("__builtin__.info = info");
             interp.exec("import net.lahwran.bukkit.jython.PythonPlugin as PythonPlugin");
             interp.exec("import net.lahwran.bukkit.jython.PythonCustomEvent as CustomEvent");
             interp.exec("import sys");

--- a/src/main/java/net/lahwran/bukkit/jython/PythonPluginLoader.java
+++ b/src/main/java/net/lahwran/bukkit/jython/PythonPluginLoader.java
@@ -282,15 +282,11 @@ public class PythonPluginLoader implements PluginLoader {
             
             interp.set("pyplugin", result);
             
-            // Load metaclass decorators from plugin
+            // Load 
             if (pyClass != null) {
-	            interp.exec(
-	            	"for method in MetaRegister.getClassMethods("+pyClass.__getattr__("__name__")+"):\r\n"+
-	            	"    MetaRegister.register(method)\r\n"+
-	            	"for method in MetaRegister.getInstanceMethods(pyplugin):\r\n"+
-	            	"    MetaRegister.register(method)\r\n"
-	            );
-            }
+	            interp.exec("MetaRegister.registerPlugin("+pyClass.__getattr__("__name__")+")");
+	        }
+            interp.exec("MetaRegister.registerStatic()");
             
             result.hooks = hook;
             result.interp = interp;

--- a/src/main/resources/scripts/meta_decorators.py
+++ b/src/main/resources/scripts/meta_decorators.py
@@ -82,7 +82,8 @@ class Listener(object):
 
 import functools
 
-def EventHandler(eventtype = None,priority = 'normal'):
+def EventHandler(argument = None,priority = 'normal'):
+    PRIORITIES = ["highest","high","normal","low","lowest","monitor"]
     def wrapper(func, eventtype, priority):
         if eventtype is None:
             try:
@@ -109,11 +110,11 @@ def EventHandler(eventtype = None,priority = 'normal'):
             func.__get__(None,int).im_func._event_handler = (eventtype,priority)
             MetaRegister.handlers.append(func.__get__(None,int).im_func)
         return func
-    if callable(eventtype) or str(type(eventtype)) == "<type 'classmethod'>" or str(type(eventtype)) == "<type 'staticmethod'>":
-        return wrapper(eventtype,None,priority)
-    return functools.partial(wrapper,eventtype=eventtype,priority=priority)
-
-
+    if callable(argument) or str(type(argument)) == "<type 'classmethod'>" or str(type(argument)) == "<type 'staticmethod'>":
+        return wrapper(argument,None,priority)
+    if argument.lower() in PRIORITIES:
+        argument,priority = priority if priority.lower() not in PRIORITIES else None,argument
+    return functools.partial(wrapper,eventtype=argument,priority=priority)
 
 def CommandHandler(command = None, desc = None, usage = None, aliases = None):
     def wrapper(func, command, desc, usage, aliases):

--- a/src/main/resources/scripts/meta_loader.py
+++ b/src/main/resources/scripts/meta_loader.py
@@ -1,0 +1,2 @@
+MetaRegister.registerPlugin(pyplugin.__class__)
+MetaRegister.registerStatic()


### PR DESCRIPTION
Hey,

I did a quick workaround to be able to use the decorators on bound methods, using an additional boolean argument for event decorators (after priority), and the additional keyword argument "deferred = True" for command decorators, to defer the event registrations for those functions until instances have been created. The registration has to be manually triggered via "hook.register(self)" from the instance, for example at the end of __init__.

It's probably not the most elegant way, but for now it works :)

zaph34r/senritsu
